### PR TITLE
change atom-panel background color

### DIFF
--- a/styles/panels.less
+++ b/styles/panels.less
@@ -13,7 +13,7 @@ atom-panel, .tool-panel {
   .text(normal);
   position: relative;
 
-  background-color: @tree-view-background-color;
+  background-color: @grey-background-color;
 
   .inset-panel {
     border-radius: @component-border-radius;


### PR DESCRIPTION
Changed the background color of atom-panel from the dark tree view color
to grey to improve readability.
